### PR TITLE
Add recalc totals checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Extends the functionality of AutomateWoo with a custom action to swap products o
 
 This action is intended to be used on manual workflows to swap out products on subscriptions in a store, on a 1:1 basis. So, when looking at the line items of an existing subscription, `Product A x3` becomes `Product B x3`. 
 
+Check the "Recalculate Totals?" checkbox if you want the subscription price to reflect the changes made to the products. Otherwise, no changes are made to any prices on the subscription.
+
 ## Notes
 - This doesn't work for Bundled Products. Let me know if this is something you want, and we can add this feature.
 - There is currently no advanced math or formulae available for this action, it just does a 1:1 swap.
-- This will not change price or quantity of line item, or any other characteristics of the subscription. It simply swaps out the product. Future update idea: Add a checkbox for "Recalculate totals?"
+- This will not change the quantity of line item, or any other characteristics of the subscription. It simply swaps out the product. Prices will only be recalculated if the "Recalculate Totals?" checkbox is checked.
 
 ## Support
 

--- a/includes/class-action-subscription-swap-product.php
+++ b/includes/class-action-subscription-swap-product.php
@@ -32,6 +32,12 @@ class Action_Subscription_Swap_Product extends Action {
 	public function load_fields() {
 		$this->add_field( $this->get_swap_out_product_select_field() );
 		$this->add_field( $this->get_swap_in_product_select_field() );
+
+		$recalculate = new Fields\Checkbox();
+		$recalculate->set_name( 'recalculate_totals' );
+		$recalculate->set_title( __( 'Recalculate Totals?', 'automatewoo' ) );
+		$recalculate->set_description( __( 'Update subscription totals to reflect the new product prices', 'automatewoo' ) );
+		$this->add_field( $recalculate );
 	}
 
 	/**
@@ -70,7 +76,7 @@ class Action_Subscription_Swap_Product extends Action {
 	protected function load_admin_details() {
 		$this->title       = __( 'Swap Product', 'automatewoo' );
 		$this->group       = __( 'Subscription', 'automatewoo' );
-		$this->description = __( 'Swap one product for another on existing subscription line items. This will not change price or quantity of line item, or any other characteristics of the subscription.', 'automatewoo' );
+		$this->description = __( 'Swap one product for another on existing subscription line items. This will not change quantity of line item, or any other characteristics of the subscription. Prices will only be recalculated if the "Recalculate Totals?" checkbox is checked.', 'automatewoo' );
 	}
 
 	/**
@@ -123,6 +129,13 @@ class Action_Subscription_Swap_Product extends Action {
 
 				// Update the order item name with the name of the new product or variation.
 				$item->set_name( $swap_in_product->get_name() );
+
+				// Add price update if recalculate is checked
+				if ( $this->get_option( 'recalculate_totals' ) ) {
+					$item->set_subtotal( $swap_in_product->get_price() * $item->get_quantity() );
+					$item->set_total( $swap_in_product->get_price() * $item->get_quantity() );
+				}
+
 				$item->save();
 
 			}
@@ -130,6 +143,12 @@ class Action_Subscription_Swap_Product extends Action {
 
 		if ( $did_update ) {
 			$this->add_subscription_note( $subscription, $swap_out_product, $swap_in_product );
+
+			// Recalculate and save totals if option is checked
+			if ( $this->get_option( 'recalculate_totals' ) ) {
+				$subscription->calculate_totals();
+				$subscription->save();
+			}
 		}
 
 	}


### PR DESCRIPTION
Check the "Recalculate Totals?" checkbox if you want the subscription price to reflect the changes made to the products. Otherwise, no changes are made to any prices on the subscription.

<img width="1277" alt="Screenshot 2025-01-06 at 19 41 02" src="https://github.com/user-attachments/assets/49f57ca2-d0a2-489c-b5b6-241998b5867b" />

## To test

1. Make two products with different prices
2. Set up a subscription which has Product A with more than one quantity
3. Set up a manual workflow which swaps Product A out and Product B in, and check the "Recalculate Totals?" checkbox
4. After running it, see that the products swapped out as expected, and the line item prices and subscription totals match what they should be for the new product
5. Verify that the quantities remain unchanged
5. Repeat the process with the checkbox unchecked, and see that the line items changed, but the prices stayed the same

